### PR TITLE
Only wait for RN bundle to load, not for RN views to render

### DIFF
--- a/detox/ios/Detox/ReactNativeSupport.m
+++ b/detox/ios/Detox/ReactNativeSupport.m
@@ -225,7 +225,7 @@ static void __setupRNSupport()
 {
 	__block __weak id observer;
 	
-	observer = [[NSNotificationCenter defaultCenter] addObserverForName:@"RCTContentDidAppearNotification" object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
+	observer = [[NSNotificationCenter defaultCenter] addObserverForName:@"RCTJavaScriptDidLoadNotification" object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
 		
 		if(handler)
 		{


### PR DESCRIPTION
Hybrid app with native initial screen is (actually) idle after it loads RN bundle, until RN stuff gets on screen. Such app, however, is never considered to be idle because it doesn't report that RN context is ready.